### PR TITLE
all: simplify import paths

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"fmt"

--- a/ast.go
+++ b/ast.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"bytes"

--- a/astutil.go
+++ b/astutil.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"fmt"

--- a/clang/cmd.go
+++ b/clang/cmd.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/termie/go-shutil"
 
-	generate "github.com/go-clang/gen"
+	"github.com/go-clang/gen"
 )
 
 // cmdFatal returns a command error
@@ -21,7 +21,7 @@ func cmdFatal(msg string, err error) error {
 }
 
 // Cmd executes a generic go-clang-generate command
-func Cmd(args []string, api *generate.API) error {
+func Cmd(args []string, api *gen.API) error {
 	rawLLVMVersion, _, err := execToBuffer("llvm-config", "--version")
 	if err != nil {
 		return cmdFatal("Cannot determine LLVM version", err)

--- a/comment.go
+++ b/comment.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"regexp"

--- a/enum.go
+++ b/enum.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"go/ast"

--- a/file.go
+++ b/file.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"bytes"

--- a/function.go
+++ b/function.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"strings"

--- a/headerfile.go
+++ b/headerfile.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"fmt"

--- a/includefiles.go
+++ b/includefiles.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 type includeFiles map[string]struct{}
 

--- a/naming.go
+++ b/naming.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"strings"

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"testing"

--- a/receiver.go
+++ b/receiver.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 // Receiver TODO refactor https://github.com/go-clang/gen/issues/52
 type Receiver struct {

--- a/struct.go
+++ b/struct.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"strings"

--- a/type.go
+++ b/type.go
@@ -1,4 +1,4 @@
-package generate
+package gen
 
 import (
 	"fmt"


### PR DESCRIPTION
- rename `package generate` into `package gen` to match import path
- simplify import path for `github.com/go-clang/gen/clang` as well