### PR TITLE
infra: add docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install install-dependencies install-tools lint pr test test-verbose
+.PHONY: all install install-dependencies install-tools lint test test-all test-verbose
 
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export ROOT_DIR
@@ -37,7 +37,7 @@ docker-images: docks/build/Dockerfile docks/base/Dockerfile
 	docker build --rm -f ./docks/base/Dockerfile  --tag=go-clang/base .
 	docker build --rm -f ./docks/build/Dockerfile --tag=go-clang/build .
 
-pr:
+test-all:
 	docker run -v $(shell pwd)/..:/go/src/github.com/go-clang \
 		-w /go/src/github.com/go-clang/gen \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ test-verbose:
 	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race -v ./...
 
 docker-images: docks/build/Dockerfile docks/base/Dockerfile
-	docker build --rm -f ./docks/base/Dockerfile  --tag=go-clang/base .
-	docker build --rm -f ./docks/build/Dockerfile --tag=go-clang/build .
+	docker build --rm -f ./docks/base/Dockerfile  --tag=goclang/base .
+	docker build --rm -f ./docks/build/Dockerfile --tag=goclang/build .
 
 test-all:
 	docker run -v $(shell pwd)/..:/go/src/github.com/go-clang \
 		-w /go/src/github.com/go-clang/gen \
 		--rm \
-		go-clang/build make all lint
+		goclang/build make all lint
 

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ test:
 	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race ./...
 test-verbose:
 	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s -race -v ./...
+
+docker-images: docks/build/Dockerfile docks/base/Dockerfile
+	docker build --rm -f ./docks/base/Dockerfile  --tag=go-clang/base .
+	docker build --rm -f ./docks/build/Dockerfile --tag=go-clang/build .
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install install-dependencies install-tools lint test test-verbose
+.PHONY: all install install-dependencies install-tools lint pr test test-verbose
 
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export ROOT_DIR
@@ -36,4 +36,10 @@ test-verbose:
 docker-images: docks/build/Dockerfile docks/base/Dockerfile
 	docker build --rm -f ./docks/base/Dockerfile  --tag=go-clang/base .
 	docker build --rm -f ./docks/build/Dockerfile --tag=go-clang/build .
+
+pr:
+	docker run -v $(shell pwd)/..:/go/src/github.com/go-clang \
+		-w /go/src/github.com/go-clang/gen \
+		--rm \
+		go-clang/build make
 

--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ pr:
 	docker run -v $(shell pwd)/..:/go/src/github.com/go-clang \
 		-w /go/src/github.com/go-clang/gen \
 		--rm \
-		go-clang/build make
+		go-clang/build make all lint
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Every PR must be prepared using the following commands:
 ```bash
 cd $GOPATH/src/github.com/go-clang/gen
 scripts/switch-clang-version.sh 3.4
-make pr
+make test-all
 ```
 
 This will switch to the current Clang version for the `go-clang-gen` command, execute all tests and process the source code with the project's linters. Make sure that you do not introduce new linting problems.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ You want to contribute to go-clang? GREAT! If you are here because of a bug you 
 
 This repository, [gen](https://github.com/go-clang/gen), holds the code to generate new bindings from headers of Clang's C API. These bindings are then bootstrapped using the [bootstrap](https://github.com/go-clang/bootstrap) repository. The `bootstrap` repository holds all basic files, like the CI configuration and a Makefile, as well as some additional code to make the bindings more complete and powerful.
 
-To ease the development process we have our own development environment based on [Vagrant](https://www.vagrantup.com/). The provided Vagrantfile executed in the root of the repository will setup an Ubuntu VM with our currently used Go version as well as Clang 3.4 and will set up everything that is needed to development and handle new versions of Clang.
+To ease the development process we have our own development environment based on [Docker](https://www.docker.com/). The provided `go-clang/build` `docker` image (located under `docks/build`) executed in the root of the repository will setup an Ubuntu image with our currently used Go version as well as Clang 3.4 and will set up everything that is needed to development and handle new versions of Clang.
 
 > **Please note**, only the major and minor version must be declared if a Clang version is needed in a command.
 
-### Generate bindings for the current Clang version (VM)
+### Generate bindings for the current Clang version (container)
 
 Make sure that the `go-clang-gen` command is up to date using `make install` in the repository's root directory. After that execute `go-clang-gen` which will generate bindings in your current directory.
 
-### Switch to a different Clang version (VM)
+### Switch to a different Clang version (container)
 
 Replace `3.4` with the Clang version you want to switch to.
 
@@ -65,11 +65,11 @@ The following sections are specific to the maintaining process.
 
 > **Please note**, only the major and minor version must be declared if a Clang version is needed in a command.
 
-### Create a new Clang version (VM)
+### Create a new Clang version (container)
 
-Every now and then a new Clang version emerges which needs to be generated using the `go-clang-gen` command. The new version has to be available using the VM's and CI's packages. Otherwise, we cannot correctly test and therefore support the version.
+Every now and then a new Clang version emerges which needs to be generated using the `go-clang-gen` command. The new version has to be available using the container's and CI's packages. Otherwise, we cannot correctly test and therefore support the version.
 
-If a new version is available create a repository on GitHub named `v<MAJOR>.<MINOR>` and set the repository description to `Go bindings for Clang's C API v<MAJOR>.<MINOR>`. Disable all repository features, e.g. `Issues` and `Wiki`. Enable the repository on TravisCI before you push anything to the repository. Lastly, execute the following command in the parent directory of the version repository inside the development VM.
+If a new version is available create a repository on GitHub named `v<MAJOR>.<MINOR>` and set the repository description to `Go bindings for Clang's C API v<MAJOR>.<MINOR>`. Disable all repository features, e.g. `Issues` and `Wiki`. Enable the repository on TravisCI before you push anything to the repository. Lastly, execute the following command in the parent directory of the version repository inside the development container.
 
 ```bash
 $GOPATH/src/github.com/go-clang/gen/scripts/create-clang-version.sh 3.4
@@ -77,9 +77,9 @@ $GOPATH/src/github.com/go-clang/gen/scripts/create-clang-version.sh 3.4
 
 This will create a new repository `v3.4` in your current directory and initialize it using the bootstrap repository. The command also generates, installs, configures and tests bindings for the given Clang version. The changes must then be manually verified, added, committed and pushed to the already set up remote "origin".
 
-### Update a branch with a new Clang version (VM)
+### Update a branch with a new Clang version (container)
 
-Every now and then a new Clang subminor version is released. The given version can be supported if packages are available inside the VM and CI. The following command can then be executed in the parent directory of the version repository inside the development VM.
+Every now and then a new Clang subminor version is released. The given version can be supported if packages are available inside the container and CI. The following command can then be executed in the parent directory of the version repository inside the development container.
 
 ```bash
 $GOPATH/src/github.com/go-clang/gen/scripts/update-clang-version.sh 3.4
@@ -89,7 +89,7 @@ This will reset the commits of the `v3.4` repository to the latest commit of the
 
 > **Please note**, since we generate the whole binding anew we do not need the old commits and thus just throw them away.
 
-### Update branches with a new `go-clang/gen` version (VM)
+### Update branches with a new `go-clang/gen` version (container)
 
 If the `go-clang-gen` command changes its generation output, all branches need to be updated which is basically just updating for a new Clang version.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ Every PR must be prepared using the following commands:
 ```bash
 cd $GOPATH/src/github.com/go-clang/gen
 scripts/switch-clang-version.sh 3.4
-make install
-make test
-make lint
+make pr
 ```
 
 This will switch to the current Clang version for the `go-clang-gen` command, execute all tests and process the source code with the project's linters. Make sure that you do not introduce new linting problems.

--- a/docks/base/Dockerfile
+++ b/docks/base/Dockerfile
@@ -1,4 +1,4 @@
-## go-clang/base
+## goclang/base
 ## an ubuntu-based docker container with go.
 from ubuntu:trusty
 maintainer go-clang-devs@github.com/go-clang

--- a/docks/base/Dockerfile
+++ b/docks/base/Dockerfile
@@ -1,0 +1,25 @@
+## go-clang/base
+## an ubuntu-based docker container with go.
+from ubuntu:trusty
+maintainer go-clang-devs@github.com/go-clang
+
+env CODENAME trusty
+env GO_VERSION 1.4.3
+
+run apt-get update -y && apt-get install -y curl
+
+## install golang
+run mkdir -p /go/src
+env GOPATH /go
+env GOROOT /usr/lib/go
+env PATH $PATH:$GOPATH/bin:$GOROOT/bin
+run cd /usr/lib && \
+	curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+	tar zxf go${GO_VERSION}.linux-amd64.tar.gz && \
+	/bin/rm go${GO_VERSION}.linux-amd64.tar.gz && \
+	go version
+
+## setup for go-clang
+workdir ${GOPATH}/github.com/go-clang/gen
+
+

--- a/docks/base/Dockerfile
+++ b/docks/base/Dockerfile
@@ -6,7 +6,9 @@ maintainer go-clang-devs@github.com/go-clang
 env CODENAME trusty
 env GO_VERSION 1.4.3
 
-run apt-get update -y && apt-get install -y curl
+run apt-get update -y && \
+	apt-get install -y curl && \
+	apt-get clean -y
 
 ## install golang
 run mkdir -p /go/src

--- a/docks/build/Dockerfile
+++ b/docks/build/Dockerfile
@@ -22,7 +22,8 @@ run apt-get update -y && \
 ## install needed packages
 run apt-get -V install -y \
 	clang-${LLVM_VERSION} git libclang-${LLVM_VERSION}-dev \
-	llvm-${LLVM_VERSION}-tools make
+	llvm-${LLVM_VERSION}-tools make \
+	gcc g++
 
 ## cleanup
 run apt-get clean -y

--- a/docks/build/Dockerfile
+++ b/docks/build/Dockerfile
@@ -1,0 +1,33 @@
+## go-clang/build
+## a Docker environment to build and test go-clang
+from go-clang/base
+maintainer go-clang-devs@github.com/go-clang
+
+env LLVM_VERSION 3.4
+
+## add repositories
+run curl -O -L http://llvm.org/apt/llvm-snapshot.gpg.key && \
+	apt-key add llvm-snapshot.gpg.key && \
+    add-apt-repository --enable-source \
+	"deb http://llvm.org/apt/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VERSION} main" && \
+	add-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+	 --recv-keys 15CF4D18AF4F7421 llvm-snapshot.gpg.key
+
+## update and upgrade
+run apt-get update -y && \
+	apt-get -V upgrade -y && \
+	apt-get -V autoremove -y
+
+## install needed packages
+run apt-get -V install -y \
+	clang-${LLVM_VERSION} git libclang-${LLVM_VERSION}-dev \
+	llvm-${LLVM_VERSION}-tools make
+
+## setup LLVM and CLang (TODO: remove. see go-clang/design#3 go-clang/gen#102)
+run ln -s /usr/bin/llvm-config-${LLVM_VERSION} /usr/bin/llvm-config && \
+	ln -s /usr/lib/x86_64-linux-gnu/libclang-${LLVM_VERSION}.so \
+		  /usr/lib/x86_64-linux-gnu/libclang.so
+
+## setup for go-clang
+workdir ${GOPATH}/github.com/go-clang/gen
+

--- a/docks/build/Dockerfile
+++ b/docks/build/Dockerfile
@@ -1,6 +1,6 @@
-## go-clang/build
+## goclang/build
 ## a Docker environment to build and test go-clang
-from go-clang/base
+from goclang/base
 maintainer go-clang-devs@github.com/go-clang
 
 env LLVM_VERSION 3.4

--- a/docks/build/Dockerfile
+++ b/docks/build/Dockerfile
@@ -6,12 +6,13 @@ maintainer go-clang-devs@github.com/go-clang
 env LLVM_VERSION 3.4
 
 ## add repositories
-run curl -O -L http://llvm.org/apt/llvm-snapshot.gpg.key && \
+run apt-get install -y software-properties-common && \
+	curl -O -L http://llvm.org/apt/llvm-snapshot.gpg.key && \
 	apt-key add llvm-snapshot.gpg.key && \
     add-apt-repository --enable-source \
-	"deb http://llvm.org/apt/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VERSION} main" && \
-	add-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-	 --recv-keys 15CF4D18AF4F7421 llvm-snapshot.gpg.key
+		"deb http://llvm.org/apt/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_VERSION} main" && \
+	/bin/rm llvm-snapshot.gpg.key
+
 
 ## update and upgrade
 run apt-get update -y && \
@@ -22,6 +23,9 @@ run apt-get update -y && \
 run apt-get -V install -y \
 	clang-${LLVM_VERSION} git libclang-${LLVM_VERSION}-dev \
 	llvm-${LLVM_VERSION}-tools make
+
+## cleanup
+run apt-get clean -y
 
 ## setup LLVM and CLang (TODO: remove. see go-clang/design#3 go-clang/gen#102)
 run ln -s /usr/bin/llvm-config-${LLVM_VERSION} /usr/bin/llvm-config && \


### PR DESCRIPTION
This CL adds docker images with `go` and LLVM/CLang installed.
- go-clang/base holds a `go` install under `/usr/lib/go` and points GOPATH at /go
- go-clang/build holds a LLVM install

Fixes go-clang/gen#100.
