### PR TITLE
Correctly handle string slice return arguments

### DIFF
--- a/type.go
+++ b/type.go
@@ -208,3 +208,12 @@ func ArrayNameFromLength(lengthCName string) string {
 
 	return ""
 }
+
+func IsInteger(typ *Type) bool {
+	switch typ.GoName {
+	case GoInt8, GoUInt8, GoInt16, GoUInt16, GoInt32, GoUInt32, GoInt64, GoUInt64:
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
This is needed for a working v3.8.