### PR TITLE
Remove the symbolic link for libClang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
 install:
   - mkdir -p /home/travis/bin
   - sudo ln -s /usr/bin/llvm-config-3.4 /home/travis/bin/llvm-config
-  - sudo ln -s /usr/lib/llvm-3.4/lib/libclang.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
   - sudo ldconfig
 
   - llvm-config --version

--- a/scripts/switch-clang-version.sh
+++ b/scripts/switch-clang-version.sh
@@ -14,7 +14,5 @@ sudo add-apt-repository --enable-source "deb http://llvm.org/apt/${CODENAME}/ ll
 sudo apt-get update
 
 sudo rm /usr/bin/llvm-config
-sudo rm /usr/lib/x86_64-linux-gnu/libclang.so
 sudo apt-get install -y clang-$LLVM_VERSION libclang1-$LLVM_VERSION libclang-$LLVM_VERSION-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev llvm-$LLVM_VERSION-runtime libclang-common-$LLVM_VERSION-dev
 sudo ln -s /usr/bin/llvm-config-$LLVM_VERSION /usr/bin/llvm-config
-sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-$LLVM_VERSION.so /usr/lib/x86_64-linux-gnu/libclang.so

--- a/scripts/vagrant-bootstrap.sh
+++ b/scripts/vagrant-bootstrap.sh
@@ -20,7 +20,6 @@ apt-get -V install -y clang-${LLVM_VERSION} git libclang-${LLVM_VERSION}-dev llv
 
 # Setup LLVM and Clang
 ln -s /usr/bin/llvm-config-$LLVM_VERSION /usr/bin/llvm-config
-ln -s /usr/lib/x86_64-linux-gnu/libclang-$LLVM_VERSION.so /usr/lib/x86_64-linux-gnu/libclang.so
 
 # Change the owner of the go directory. This is needed because the missing parent folders up to our synced folder are created with the user "root" instead of "vagrant".
 chown -R vagrant:vagrant /home/vagrant/go


### PR DESCRIPTION
This is not needed anymore, or it was never needed?!