### PR TITLE
Switch to Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.7.1
+  - 1.7.x
+  - 1.8.x
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,5 @@ script:
   # Do tests and code coverage
   - make test-full
 
-  - ginkgo -cover -skipPackage="testdata"
-  - gover
+  - make test-coverage
   - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN; fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install install-dependencies install-tools lint test test-full test-verbose
+.PHONY: all install install-dependencies install-tools lint test test-coverage test-full test-verbose
 
 export ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -33,6 +33,9 @@ lint: install
 	$(ROOT_DIR)/scripts/lint.sh
 test:
 	CGO_LDFLAGS="-L`llvm-config --libdir`" go test -timeout 60s ./...
+test-coverage:
+	ginkgo -cover -skipPackage="testdata"
+	gover
 test-full:
 	$(ROOT_DIR)/scripts/test-full.sh
 test-verbose:


### PR DESCRIPTION
We are only supporting the two latest major Go releases.

This PR has a partner https://github.com/go-clang/bootstrap/pull/18 both have to pass.