### PR TITLE
Support LLVM 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,20 @@ cache:
 git:
  depth: 10
 
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.5
+      - llvm-toolchain-trusty-3.9
     packages:
-      - llvm-3.5
-      - clang-3.5
-      - libclang1-3.5
-      - libclang-3.5-dev
+      - llvm-3.9
+      - clang-3.9
+      - libclang-3.9-dev
 
 env:
   global:
@@ -32,9 +36,9 @@ env:
 
 install:
   - mkdir -p /home/travis/bin
-  - sudo ln -s /usr/bin/clang-3.5 /home/travis/bin/clang
-  - sudo ln -s /usr/bin/clang++-3.5 /home/travis/bin/clang++
-  - sudo ln -s /usr/bin/llvm-config-3.5 /home/travis/bin/llvm-config
+  - sudo ln -s /usr/bin/clang-3.9 /home/travis/bin/clang
+  - sudo ln -s /usr/bin/clang++-3.9 /home/travis/bin/clang++
+  - sudo ln -s /usr/bin/llvm-config-3.9 /home/travis/bin/llvm-config
   - sudo ldconfig
 
   - llvm-config --version

--- a/ast.go
+++ b/ast.go
@@ -234,7 +234,7 @@ func (fa *ASTFunc) generateParameters() []ast.Expr {
 		} else if p.Type.PointerLevel > 0 && p.Type.IsPrimitive && p.Type.CGoName != CSChar {
 			hasDeclaration = true
 
-			var varType = doCType(p.Type.CGoName)
+			varType := doCType(p.Type.CGoName)
 
 			fa.addStatement(doDeclare(
 				"cp_"+p.Name,

--- a/ast.go
+++ b/ast.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"go/format"
 	"go/token"
@@ -40,7 +41,7 @@ func generateFunctionString(fa *ASTFunc) string {
 	var b bytes.Buffer
 	err := format.Node(&b, token.NewFileSet(), []ast.Decl{fa.FuncDecl})
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("unexpected error: %w", err))
 	}
 
 	fStr := b.String()

--- a/astutil.go
+++ b/astutil.go
@@ -52,7 +52,7 @@ func doDeclare(name string, typ ast.Expr) *ast.DeclStmt {
 			Specs: []ast.Spec{
 				&ast.ValueSpec{
 					Names: []*ast.Ident{
-						&ast.Ident{
+						{
 							Name: name,
 						},
 					},
@@ -68,7 +68,7 @@ func doField(name string, typ Type) *ast.Field {
 
 	if name != "" {
 		f.Names = []*ast.Ident{
-			&ast.Ident{
+			{
 				Name: name,
 			},
 		}

--- a/clang/cmd.go
+++ b/clang/cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-clang/gen"
@@ -90,6 +91,13 @@ func Cmd(llvmConfigPath string, api *gen.API) error {
 				}
 			}
 		}
+	}
+
+	const doc = `// Package clang-c holds clang binding C header files.
+package clang_c
+`
+	if err := ioutil.WriteFile(filepath.Join(clangCDirectory, "doc.go"), []byte(doc), 0o600); err != nil {
+		return err
 	}
 
 	headerFiles, err := api.HandleDirectory(clangCDirectory)

--- a/clang/cmd.go
+++ b/clang/cmd.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/termie/go-shutil"
-
 	"github.com/go-clang/gen"
 )
 
@@ -75,7 +73,7 @@ func Cmd(llvmConfigPath string, api *gen.API) error {
 
 	// Copy the Clang-C include directory into the current directory
 	_ = os.RemoveAll(clangCDirectory)
-	if err := shutil.CopyTree(clangCIncludeDir, clangCDirectory, nil); err != nil {
+	if err := copyTree(clangCIncludeDir, clangCDirectory); err != nil {
 		return cmdFatal(fmt.Sprintf("Cannot copy Clang-C include directory %q into current directory", clangCIncludeDir), err)
 	}
 

--- a/clang/cmd.go
+++ b/clang/cmd.go
@@ -67,7 +67,7 @@ func Cmd(llvmConfigPath string, api *gen.API) error {
 
 	api.ClangArguments = append(clangArguments, api.ClangArguments...)
 
-	fmt.Printf("Using clang arguments: %v\n", clangArguments)
+	fmt.Printf("Using clang arguments: %v\n", api.ClangArguments)
 
 	fmt.Printf("Will generate go-clang for LLVM version %s into the current directory\n", llvmVersion.String())
 

--- a/clang/cmd.go
+++ b/clang/cmd.go
@@ -21,8 +21,8 @@ func cmdFatal(msg string, err error) error {
 }
 
 // Cmd executes a generic go-clang-generate command
-func Cmd(args []string, api *gen.API) error {
-	rawLLVMVersion, _, err := execToBuffer("llvm-config", "--version")
+func Cmd(llvmConfigPath string, api *gen.API) error {
+	rawLLVMVersion, _, err := execToBuffer(llvmConfigPath, "--version")
 	if err != nil {
 		return cmdFatal("Cannot determine LLVM version", err)
 	}
@@ -34,7 +34,7 @@ func Cmd(args []string, api *gen.API) error {
 
 	fmt.Println("Found LLVM version", llvmVersion.String())
 
-	rawLLVMIncludeDir, _, err := execToBuffer("llvm-config", "--includedir")
+	rawLLVMIncludeDir, _, err := execToBuffer(llvmConfigPath, "--includedir")
 	if err != nil {
 		return cmdFatal("Cannot determine LLVM include directory", err)
 	}

--- a/enum.go
+++ b/enum.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"strings"
 
-	"github.com/go-clang/bootstrap/clang"
+	"github.com/go-clang/clang-v3.9/clang"
 )
 
 // Enum represents a generation enum

--- a/enum.go
+++ b/enum.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"fmt"
 	"go/ast"
 	"strings"
 
@@ -86,7 +87,7 @@ func handleEnumCursor(cursor clang.Cursor, cname string, cnameIsTypeDef bool) *E
 
 			e.Items = append(e.Items, ei)
 		default:
-			panic(cursor.Kind())
+			panic(fmt.Errorf("unexpected cursor.Kind: %#v", cursor.Kind()))
 		}
 
 		return clang.ChildVisit_Continue

--- a/file.go
+++ b/file.go
@@ -103,12 +103,12 @@ func (f *File) generate() error {
 	out, err := imports.Process(filename, bo, nil)
 	if err != nil {
 		// Write the file anyway so we can look at the problem
-		if err := ioutil.WriteFile(filename, bo, 0600); err != nil {
+		if err := ioutil.WriteFile(filename, bo, 0o600); err != nil {
 			return err
 		}
 
 		return err
 	}
 
-	return ioutil.WriteFile(filename, out, 0600)
+	return ioutil.WriteFile(filename, out, 0o600)
 }

--- a/function.go
+++ b/function.go
@@ -42,7 +42,7 @@ func newFunction(name, cname, comment, member string, typ Type) *Function {
 		IncludeFiles: newIncludeFiles(),
 
 		Parameters: []FunctionParameter{ // TODO this might not be needed if the receiver code is refactored https://github.com/go-clang/gen/issues/52
-			FunctionParameter{
+			{
 				Name:  receiverName,
 				CName: cname,
 				Type: Type{

--- a/function.go
+++ b/function.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-clang/clang-v3.9/clang"
@@ -82,7 +83,7 @@ func handleFunctionCursor(cursor clang.Cursor) *Function {
 
 	typ, err := typeFromClangType(cursor.ResultType())
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("unexpected cursor.ResultType: %#v: %w", cursor.ResultType(), err))
 	}
 	f.ReturnType = typ
 
@@ -96,7 +97,7 @@ func handleFunctionCursor(cursor clang.Cursor) *Function {
 
 		typ, err := typeFromClangType(param.Type())
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("unexpected error: %w, param.Type(): %#v", err, param.Type()))
 		}
 		p.Type = typ
 

--- a/function.go
+++ b/function.go
@@ -3,7 +3,7 @@ package gen
 import (
 	"strings"
 
-	"github.com/go-clang/bootstrap/clang"
+	"github.com/go-clang/clang-v3.9/clang"
 )
 
 // Function represents a generation function

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-clang/gen
 go 1.13
 
 require (
-	github.com/go-clang/bootstrap v0.0.0-20161204104621-46910c2bedc8
+	github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517
 	github.com/stretchr/testify v1.6.1
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	golang.org/x/tools v0.0.0-20200922173257-82fe25c37531

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.13
 require (
 	github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517
 	github.com/stretchr/testify v1.6.1
-	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
 	golang.org/x/tools v0.0.0-20200922173257-82fe25c37531
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae h1:vgGSvdW5Lqg+I1aZOlG32uyE6xHpLdKhZzcTEktz5wM=
-github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae/go.mod h1:quDq6Se6jlGwiIKia/itDZxqC5rj6/8OdFyMMAwTxCs=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-clang/bootstrap v0.0.0-20161204104621-46910c2bedc8 h1:48pEWKUx3vM9V3F7xsw0Q3rrnokOhB2pwaDKdHDZRWE=
-github.com/go-clang/bootstrap v0.0.0-20161204104621-46910c2bedc8/go.mod h1:kgi2wxZchC9oYF2q3w+nE1xdlxJjBBEsQ8FIU1z3Ijs=
+github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517 h1:6w6Fs0cbVQrR2Izm7MMzTkaH9d5t9wvPk8JFgHz+fSc=
+github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517/go.mod h1:7t/KkSk9wzoJahgW6/l67p6B109wyxcSZRlz1rmr7+A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/headerfile.go
+++ b/headerfile.go
@@ -63,7 +63,7 @@ func (h *HeaderFile) prepareFile() error {
 	if incl := "#include <stdint.h>"; !strings.HasPrefix(fs, incl) { // Include for uintptr_t
 		fs = "#include <stdint.h>\n\n" + fs
 	}
-	err = ioutil.WriteFile(h.FullPath(), []byte(fs), 0600)
+	err = ioutil.WriteFile(h.FullPath(), []byte(fs), 0o600)
 	if err != nil {
 		return fmt.Errorf("Cannot write %s: %v", h.FullPath(), err)
 	}

--- a/headerfile.go
+++ b/headerfile.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-clang/bootstrap/clang"
+	"github.com/go-clang/clang-v3.9/clang"
 )
 
 type HeaderFile struct {

--- a/headerfile.go
+++ b/headerfile.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -85,6 +86,10 @@ func (h *HeaderFile) handleFile(cursor clang.Cursor) {
 		isCurrentFile := sourceFile.Name() == h.FullPath()
 
 		if !strings.HasPrefix(sourceFile.Name(), h.Path) {
+			return clang.ChildVisit_Continue
+		}
+		// TODO(zchee): Documentation.h header haven't correct cursor information
+		if h.Filename == "Documentation.h" && filepath.Base(sourceFile.Name()) == "Index.h" {
 			return clang.ChildVisit_Continue
 		}
 

--- a/lookup.go
+++ b/lookup.go
@@ -11,7 +11,7 @@ func NewLookup() Lookup {
 		lookupEnum:        map[string]*Enum{},
 		lookupNonTypedefs: map[string]string{},
 		lookupStruct: map[string]*Struct{
-			"cxstring": &Struct{
+			"cxstring": {
 				Name:  "cxstring",
 				CName: "CXString",
 			},

--- a/struct.go
+++ b/struct.go
@@ -44,7 +44,7 @@ func handleStructCursor(cursor clang.Cursor, cname string, cnameIsTypeDef bool) 
 	s.Name = TrimLanguagePrefix(s.CName)
 	s.Receiver.Name = commonReceiverName(s.Name)
 
-	cursor.Visit(func(cursor, parent clang.Cursor) clang.ChildVisitResult {
+	cursor.Visit(func(cursor, _ clang.Cursor) clang.ChildVisitResult {
 		switch cursor.Kind() {
 		case clang.Cursor_FieldDecl:
 			typ, err := typeFromClangType(cursor.Type())

--- a/struct.go
+++ b/struct.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-clang/clang-v3.9/clang"
@@ -48,7 +49,7 @@ func handleStructCursor(cursor clang.Cursor, cname string, cnameIsTypeDef bool) 
 		case clang.Cursor_FieldDecl:
 			typ, err := typeFromClangType(cursor.Type())
 			if err != nil {
-				panic(err)
+				panic(fmt.Errorf("unexpected error: %w, cursor.Type(): %#v", err, cursor.Type()))
 			}
 
 			if typ.IsFunctionPointer {

--- a/struct.go
+++ b/struct.go
@@ -3,7 +3,7 @@ package gen
 import (
 	"strings"
 
-	"github.com/go-clang/bootstrap/clang"
+	"github.com/go-clang/clang-v3.9/clang"
 )
 
 // Struct represents a generation struct

--- a/type.go
+++ b/type.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/go-clang/bootstrap/clang"
+	"github.com/go-clang/clang-v3.9/clang"
 )
 
 // Defines all available Go types

--- a/type.go
+++ b/type.go
@@ -178,6 +178,8 @@ func typeFromClangType(cType clang.Type) (Type, error) {
 		typ.GoName = TrimLanguagePrefix(cType.Declaration().DisplayName())
 		typ.IsEnumLiteral = true
 		typ.IsPrimitive = true
+	case clang.Type_Elaborated:
+		return typeFromClangType(cType.CanonicalType())
 	case clang.Type_Unexposed: // There is a bug in clang for enums the kind is set to unexposed dunno why, bug persists since 2013 https://llvm.org/bugs/show_bug.cgi?id=15089
 		subTyp, err := typeFromClangType(cType.CanonicalType())
 		if err != nil {


### PR DESCRIPTION
Support LLVM 3.9.

Basically, for upgrade(regenerate) [go-clang/bootstrap](https://github.com/go-clang/bootstrap) package. Now depends on [go-clang/clang-v3.9](https://github.com/go-clang/clang-v3.9), I'll switch back to [go-clang/bootstrap](https://github.com/go-clang/bootstrap) when after merge this pull request.

- `clang,cmd: add clang-resource-dir and llvm-config flags`
	- for the generate on the non Vagrant VM environment such as darwin with native or Docker for Mac.
I manage each version of llvm resources for this project in `/opt/llvm`. So added it.
The `clang-resource-dir` naming is from the `clang --print-resource-dir` flag which is implemented after the LLVM 5.0.
- `clang: add package clang-c/doc.go generation`
	- It's still WIP. Please let me know if you have any other ideas for a good place.
- `gen: add temporary hack for Documentation.h header`
	- It's a temporary hack. I don't know yet why needs it. will dig and resolve it.

Update: #141