### PR TITLE
all: switch back to github.com/go-clang/bootstrap

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"strings"
 
-	"github.com/go-clang/clang-v3.9/clang"
+	"github.com/go-clang/bootstrap/clang"
 )
 
 // Enum represents a generation enum

--- a/function.go
+++ b/function.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-clang/clang-v3.9/clang"
+	"github.com/go-clang/bootstrap/clang"
 )
 
 // Function represents a generation function

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-clang/gen
 go 1.13
 
 require (
-	github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517
+	github.com/go-clang/bootstrap v0.0.0-20201004201401-dad59216e055
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/tools v0.0.0-20200922173257-82fe25c37531
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517 h1:6w6Fs0cbVQrR2Izm7MMzTkaH9d5t9wvPk8JFgHz+fSc=
-github.com/go-clang/clang-v3.9 v0.0.0-20200924085731-98695937b517/go.mod h1:7t/KkSk9wzoJahgW6/l67p6B109wyxcSZRlz1rmr7+A=
+github.com/go-clang/bootstrap v0.0.0-20201004201401-dad59216e055 h1:zAyXlDeM22gtwHTqgnt569O+LzOlS3S1qmEOrGwY48w=
+github.com/go-clang/bootstrap v0.0.0-20201004201401-dad59216e055/go.mod h1:dpmmKECK7R0fK/ZjJafcN2aCG2pvdyhvKM6nNlBRtPE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/headerfile.go
+++ b/headerfile.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-clang/clang-v3.9/clang"
+	"github.com/go-clang/bootstrap/clang"
 )
 
 type HeaderFile struct {

--- a/struct.go
+++ b/struct.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-clang/clang-v3.9/clang"
+	"github.com/go-clang/bootstrap/clang"
 )
 
 // Struct represents a generation struct

--- a/type.go
+++ b/type.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/go-clang/clang-v3.9/clang"
+	"github.com/go-clang/bootstrap/clang"
 )
 
 // Defines all available Go types


### PR DESCRIPTION
Switch back to `github.com/go-clang/bootstrap`.