### PR TITLE
naming: exclude genCXXManglings and getObjCManglings and add testcase

### DIFF
--- a/naming.go
+++ b/naming.go
@@ -79,7 +79,13 @@ func TrimCommonFunctionNamePrefix(name string) string {
 		name = strings.TrimPrefix(name, "Get")
 	}
 
-	name = TrimLanguagePrefix(name)
+	switch name {
+	case "CXXManglings", "ObjCManglings":
+		// nothing to do
+
+	default:
+		name = TrimLanguagePrefix(name)
+	}
 
 	return name
 }

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,7 +1,9 @@
-package gen
+package gen_test
 
 import (
 	"testing"
+
+	"github.com/go-clang/gen"
 )
 
 func TestUpperFirstCharacter(t *testing.T) {
@@ -43,8 +45,52 @@ func TestUpperFirstCharacter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got, want := UpperFirstCharacter(tt.data), tt.expect; got != want {
+			if got, want := gen.UpperFirstCharacter(tt.data), tt.expect; got != want {
 				t.Fatalf("got %s but want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestTrimCommonFunctionNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name string
+		want string
+	}{
+		"createCXCursorSet": {
+			name: "createCXCursorSet",
+			want: "CursorSet",
+		},
+		"getKind": {
+			name: "getKind",
+			want: "Kind",
+		},
+		"GetObjCSelector": {
+			name: "GetObjCSelector",
+			want: "Selector",
+		},
+		"getCXXManglings": {
+			name: "getCXXManglings",
+			want: "CXXManglings",
+		},
+		"getObjCManglings": {
+			name: "getObjCManglings",
+			want: "ObjCManglings",
+		},
+		"SourceLocation": {
+			name: "SourceLocation",
+			want: "SourceLocation",
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := gen.TrimCommonFunctionNamePrefix(tt.name); got != tt.want {
+				t.Fatalf("TrimCommonFunctionNamePrefix(%v) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Exclude `genCXXManglings` and `getObjCManglings` for clang-v6 and add testcase.