### PR TITLE
module: upgrade go-clang/bootstrap to v0.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "main"
 
 env:
-  LLVM_VERSION: 5
+  LLVM_VERSION: 6
 
 jobs:
   test:
@@ -19,13 +19,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Test in Docker
       run: |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-clang/gen
 go 1.17
 
 require (
-	github.com/go-clang/bootstrap v0.5.0
+	github.com/go-clang/bootstrap v0.6.0
 	github.com/google/go-cmp v0.5.6
 	golang.org/x/tools v0.1.8-0.20211109164901-e9000123914f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-clang/bootstrap v0.5.0 h1:6TzT+k9Mg2PgFlE0EmHKavdHYDAh98PbvD52rmjv2ik=
-github.com/go-clang/bootstrap v0.5.0/go.mod h1:a4EmDb8BXcdDBkMbvviEzrDd2LNZXqY7PwHmeyHKy1k=
+github.com/go-clang/bootstrap v0.6.0 h1:1hHcrC1rhhvha1O//hwBbn9oH7ewl9M3hphmmkFZ6W0=
+github.com/go-clang/bootstrap v0.6.0/go.mod h1:a4EmDb8BXcdDBkMbvviEzrDd2LNZXqY7PwHmeyHKy1k=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
module: upgrade go-clang/bootstrap to v0.6.0.