### PR TITLE
module: upgrade go-clang/bootstrap to v0.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "main"
 
 env:
-  LLVM_VERSION: 10
+  LLVM_VERSION: 11
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-clang/gen
 go 1.17
 
 require (
-	github.com/go-clang/bootstrap v0.10.0
+	github.com/go-clang/bootstrap v0.11.0
 	github.com/google/go-cmp v0.5.6
 	golang.org/x/tools v0.1.8-0.20211109164901-e9000123914f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-clang/bootstrap v0.10.0 h1:o66C04H2fQrgRNn5p6ux+iWqOw3dWzO2ka2K6hhzSMk=
-github.com/go-clang/bootstrap v0.10.0/go.mod h1:a4EmDb8BXcdDBkMbvviEzrDd2LNZXqY7PwHmeyHKy1k=
+github.com/go-clang/bootstrap v0.11.0 h1:c34Vs7ckCpD3XYO7D4CqXzQNnq31vTZcuj+39jHtUWQ=
+github.com/go-clang/bootstrap v0.11.0/go.mod h1:a4EmDb8BXcdDBkMbvviEzrDd2LNZXqY7PwHmeyHKy1k=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
module: upgrade go-clang/bootstrap to v0.11.0.